### PR TITLE
Support for multiple batches per optimizer step

### DIFF
--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -299,9 +299,9 @@ class Experiment:
                                             epochs=epochs,
                                             steps_per_epoch=steps_per_epoch,
                                             validation_steps=validation_steps,
+                                            batches_per_step=batches_per_step,
                                             initial_epoch=initial_epoch,
-                                            callbacks=callbacks,
-                                            batches_per_step=batches_per_step)
+                                            callbacks=callbacks)
         finally:
             if tensorboard_writer is not None:
                 tensorboard_writer.close()

--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -239,8 +239,8 @@ class Experiment:
               epochs=1000,
               steps_per_epoch=None,
               validation_steps=None,
-              seed=42,
-              batches_per_step=1):
+              batches_per_step=1,
+              seed=42):
         # pylint: disable=too-many-locals
         if seed is not None:
             # Make training deterministic.

--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -241,6 +241,7 @@ class Experiment:
               validation_steps=None,
               seed=42,
               batches_between_backprops=1):
+        # pylint: disable=too-many-locals
         if seed is not None:
             # Make training deterministic.
             random.seed(seed)

--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -240,7 +240,7 @@ class Experiment:
               steps_per_epoch=None,
               validation_steps=None,
               seed=42,
-              batches_between_backprops=1):
+              batches_per_step=1):
         # pylint: disable=too-many-locals
         if seed is not None:
             # Make training deterministic.
@@ -301,7 +301,7 @@ class Experiment:
                                             validation_steps=validation_steps,
                                             initial_epoch=initial_epoch,
                                             callbacks=callbacks,
-                                            batches_between_backprops=batches_between_backprops)
+                                            batches_per_step=batches_per_step)
         finally:
             if tensorboard_writer is not None:
                 tensorboard_writer.close()

--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -239,7 +239,8 @@ class Experiment:
               epochs=1000,
               steps_per_epoch=None,
               validation_steps=None,
-              seed=42):
+              seed=42,
+              batches_between_backprops=1):
         if seed is not None:
             # Make training deterministic.
             random.seed(seed)
@@ -298,7 +299,8 @@ class Experiment:
                                             steps_per_epoch=steps_per_epoch,
                                             validation_steps=validation_steps,
                                             initial_epoch=initial_epoch,
-                                            callbacks=callbacks)
+                                            callbacks=callbacks,
+                                            batches_between_backprops=batches_between_backprops)
         finally:
             if tensorboard_writer is not None:
                 tensorboard_writer.close()

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -53,7 +53,7 @@ class StepIterator:
         for step, data in _get_step_iterator(self.steps_per_epoch, self.generator):
             self.callback.on_batch_begin(step, {})
 
-            zero_all_gradients = ((step + 1) % self.steps_between_backprops == 0)
+            zero_all_gradients = (steps % self.steps_between_backprops == 1)
             do_backprop = (step % self.steps_between_backprops == 0) or (step == self.steps_per_epoch)
 
             step_data = Step(step, zero_all_gradients, do_backprop)

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -6,10 +6,8 @@ from .callbacks import Callback
 
 
 class Step:
-    def __init__(self, number, zero_all_gradients=True, do_backprop=True):
+    def __init__(self, number):
         self.number = number
-        self.zero_all_gradients = zero_all_gradients
-        self.do_backprop = do_backprop
 
         self.loss = None
         self.metrics = None
@@ -54,10 +52,7 @@ class StepIterator:
         for step, data in _get_step_iterator(self.steps_per_epoch, self.generator):
             self.callback.on_batch_begin(step, {})
 
-            zero_all_gradients = ((step - 1) % self.batches_per_step == 0)
-            do_backprop = (step % self.batches_per_step == 0) or (step == self.steps_per_epoch)
-
-            step_data = Step(step, zero_all_gradients, do_backprop)
+            step_data = Step(step)
             yield step_data, data
 
             self.losses_sum += step_data.loss * step_data.size

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -53,7 +53,7 @@ class StepIterator:
         for step, data in _get_step_iterator(self.steps_per_epoch, self.generator):
             self.callback.on_batch_begin(step, {})
 
-            zero_all_gradients = (steps % self.steps_between_backprops == 1)
+            zero_all_gradients = (step % self.steps_between_backprops == 1)
             do_backprop = (step % self.steps_between_backprops == 0) or (step == self.steps_per_epoch)
 
             step_data = Step(step, zero_all_gradients, do_backprop)

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -30,6 +30,7 @@ def _get_step_iterator(steps, generator):
 
 class StepIterator:
     def __init__(self, generator, steps_per_epoch, callback, metrics_names, batches_between_backprops=1):
+        # pylint: disable=too-many-arguments
         self.generator = generator
         self.steps_per_epoch = steps_per_epoch
         self.callback = callback

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -54,7 +54,7 @@ class StepIterator:
         for step, data in _get_step_iterator(self.steps_per_epoch, self.generator):
             self.callback.on_batch_begin(step, {})
 
-            zero_all_gradients = (step % self.batches_between_backprops == 1)
+            zero_all_gradients = ((step - 1) % self.batches_between_backprops == 0)
             do_backprop = (step % self.batches_between_backprops == 0) or (step == self.steps_per_epoch)
 
             step_data = Step(step, zero_all_gradients, do_backprop)

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -29,12 +29,12 @@ def _get_step_iterator(steps, generator):
 
 
 class StepIterator:
-    def __init__(self, generator, steps_per_epoch, callback, metrics_names, steps_between_backprops=1):
+    def __init__(self, generator, steps_per_epoch, callback, metrics_names, batches_between_backprops=1):
         self.generator = generator
         self.steps_per_epoch = steps_per_epoch
         self.callback = callback
         self.metrics_names = metrics_names
-        self.steps_between_backprops = steps_between_backprops
+        self.batches_between_backprops = batches_between_backprops
 
         self.losses_sum = 0.
         self.metrics_sum = np.zeros(len(self.metrics_names))
@@ -53,8 +53,8 @@ class StepIterator:
         for step, data in _get_step_iterator(self.steps_per_epoch, self.generator):
             self.callback.on_batch_begin(step, {})
 
-            zero_all_gradients = (step % self.steps_between_backprops == 1)
-            do_backprop = (step % self.steps_between_backprops == 0) or (step == self.steps_per_epoch)
+            zero_all_gradients = (step % self.batches_between_backprops == 1)
+            do_backprop = (step % self.batches_between_backprops == 0) or (step == self.steps_per_epoch)
 
             step_data = Step(step, zero_all_gradients, do_backprop)
             yield step_data, data
@@ -88,7 +88,7 @@ class EpochIterator:
                  initial_epoch=1,
                  callback,
                  metrics_names,
-                 steps_between_backprops=1):
+                 batches_between_backprops=1):
         self.train_generator = train_generator
         self.valid_generator = valid_generator
         self.epochs = epochs
@@ -97,7 +97,7 @@ class EpochIterator:
         self.initial_epoch = initial_epoch
         self.callback = callback
         self.metrics_names = metrics_names
-        self.steps_between_backprops = steps_between_backprops
+        self.batches_between_backprops = batches_between_backprops
         self.epoch_logs = []
         self.stop_training = False
 
@@ -124,12 +124,12 @@ class EpochIterator:
             epoch_begin_time = timeit.default_timer()
 
             train_step_iterator = StepIterator(self.train_generator, self.steps_per_epoch, self.callback,
-                                               self.metrics_names, self.steps_between_backprops)
+                                               self.metrics_names, self.batches_between_backprops)
 
             valid_step_iterator = None
             if self.valid_generator is not None:
                 valid_step_iterator = StepIterator(self.valid_generator, self.validation_steps, Callback(),
-                                                   self.metrics_names, self.steps_between_backprops)
+                                                   self.metrics_names, self.batches_between_backprops)
 
             yield train_step_iterator, valid_step_iterator
 

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -28,7 +28,6 @@ def _get_step_iterator(steps, generator):
 
 class StepIterator:
     def __init__(self, generator, steps_per_epoch, callback, metrics_names):
-        # pylint: disable=too-many-arguments
         self.generator = generator
         self.steps_per_epoch = steps_per_epoch
         self.callback = callback

--- a/poutyne/framework/iterators.py
+++ b/poutyne/framework/iterators.py
@@ -27,13 +27,12 @@ def _get_step_iterator(steps, generator):
 
 
 class StepIterator:
-    def __init__(self, generator, steps_per_epoch, callback, metrics_names, batches_per_step=1):
+    def __init__(self, generator, steps_per_epoch, callback, metrics_names):
         # pylint: disable=too-many-arguments
         self.generator = generator
         self.steps_per_epoch = steps_per_epoch
         self.callback = callback
         self.metrics_names = metrics_names
-        self.batches_per_step = batches_per_step
 
         self.losses_sum = 0.
         self.metrics_sum = np.zeros(len(self.metrics_names))
@@ -83,8 +82,7 @@ class EpochIterator:
                  validation_steps,
                  initial_epoch=1,
                  callback,
-                 metrics_names,
-                 batches_per_step=1):
+                 metrics_names):
         self.train_generator = train_generator
         self.valid_generator = valid_generator
         self.epochs = epochs
@@ -93,7 +91,6 @@ class EpochIterator:
         self.initial_epoch = initial_epoch
         self.callback = callback
         self.metrics_names = metrics_names
-        self.batches_per_step = batches_per_step
         self.epoch_logs = []
         self.stop_training = False
 
@@ -120,12 +117,12 @@ class EpochIterator:
             epoch_begin_time = timeit.default_timer()
 
             train_step_iterator = StepIterator(self.train_generator, self.steps_per_epoch, self.callback,
-                                               self.metrics_names, self.batches_per_step)
+                                               self.metrics_names)
 
             valid_step_iterator = None
             if self.valid_generator is not None:
                 valid_step_iterator = StepIterator(self.valid_generator, self.validation_steps, Callback(),
-                                                   self.metrics_names, self.batches_per_step)
+                                                   self.metrics_names)
 
             yield train_step_iterator, valid_step_iterator
 

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -144,10 +144,10 @@ class Model:
             epochs=1000,
             steps_per_epoch=None,
             validation_steps=None,
+            batches_per_step=1,
             initial_epoch=1,
             verbose=True,
-            callbacks=None,
-            batches_per_step=1):
+            callbacks=None):
         # pylint: disable=line-too-long
         # pylint: disable=too-many-arguments
         """
@@ -178,6 +178,10 @@ class Model:
                 dataset.
                 (Defaults to ``steps_per_epoch`` if provided or the number of steps needed to
                 see the entire validation dataset)
+            batches_per_step (int): Number of batches on which to compute the running loss before
+                backpropagating it through the network. Note that the total loss used for backpropagation is
+                the mean of the `batches_per_step` batch losses.
+                (Default value = 1)
             initial_epoch (int, optional): Epoch at which to start training
                 (useful for resuming a previous training run).
                 (Default value = 1)
@@ -186,10 +190,6 @@ class Model:
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called
                 during training.
                 (Default value = None)
-            batches_per_step (int): Number of batches on which to compute the running loss before
-                backpropagating it through the network. Note that the total loss used for backpropagation is
-                the mean of the `batches_per_step` batch losses.
-                (Default value = 1)
 
         Returns:
             List of dict containing the history of each epoch.
@@ -241,10 +241,10 @@ class Model:
                       epochs=1000,
                       steps_per_epoch=None,
                       validation_steps=None,
+                      batches_per_step=1,
                       initial_epoch=1,
                       verbose=True,
-                      callbacks=None,
-                      batches_per_step=1):
+                      callbacks=None):
         # pylint: disable=too-many-locals, line-too-long
         """
         Trains the model on a dataset using a generator.
@@ -280,6 +280,10 @@ class Model:
             validation_steps (int, optional): Same as for ``steps_per_epoch`` but for the validation dataset.
                 (Defaults to ``steps_per_epoch`` if provided or the number of steps needed to see the entire
                 validation dataset)
+            batches_per_step (int): Number of batches on which to compute the running loss before
+                backpropagating it through the network. Note that the total loss used for backpropagation is
+                the mean of the `batches_per_step` batch losses.
+                (Default value = 1)
             initial_epoch (int, optional): Epoch at which to start training (useful for resuming a previous
                 training run).
                 (Default value = 1)
@@ -287,10 +291,6 @@ class Model:
                 (Default value = True)
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called during training.
                 (Default value = None)
-            batches_per_step (int): Number of batches on which to compute the running loss before
-                backpropagating it through the network. Note that the total loss used for backpropagation is
-                the mean of the `batches_per_step` batch losses.
-                (Default value = 1)
 
         Returns:
             List of dict containing the history of each epoch.

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -340,7 +340,8 @@ class Model:
                                                                  callback=callback_list,
                                                                  step=step.number,
                                                                  zero_all_gradients=step.zero_all_gradients,
-                                                                 do_backprop=step.do_backprop)
+                                                                 do_backprop=step.do_backprop,
+                                                                 batches_between_backprops=batches_between_backprops)
                     step.size = self._get_batch_size(x, y)
 
             if valid_step_iterator is not None:

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -117,6 +117,7 @@ class Model:
             ...
 
     """
+
     def __init__(self, model, optimizer, loss_function, *, metrics=None):
         metrics = [] if metrics is None else metrics
 

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -237,7 +237,7 @@ class Model:
                       initial_epoch=1,
                       verbose=True,
                       callbacks=None,
-                      steps_between_backprops=1):
+                      batches_between_backprops=1):
         # pylint: disable=too-many-locals, line-too-long
         """
         Trains the model on a dataset using a generator.
@@ -280,6 +280,10 @@ class Model:
                 (Default value = True)
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called during training.
                 (Default value = None)
+            batches_between_backprops (int): Number of batches on which to compute the running loss before 
+                backpropagating it through the network. Note that the total loss used for backpropagation is
+                the mean of the `batches_between_backprops` batch losses.
+                (Default value = 1)
 
         Returns:
             List of dict containing the history of each epoch.
@@ -320,7 +324,7 @@ class Model:
                                        initial_epoch=initial_epoch,
                                        callback=callback_list,
                                        metrics_names=self.metrics_names,
-                                       steps_between_backprops=steps_between_backprops)
+                                       batches_between_backprops=batches_between_backprops)
 
         for train_step_iterator, valid_step_iterator in epoch_iterator:
             with self._set_training_mode(True):
@@ -349,7 +353,7 @@ class Model:
                    return_pred=False,
                    zero_all_gradients=True,
                    do_backprop=True,
-                   steps_between_backprops=1):
+                   batches_between_backprops=1):
         if zero_all_gradients:
             self.optimizer.zero_grad()
 
@@ -358,7 +362,7 @@ class Model:
                                                                       return_loss_tensor=True,
                                                                       return_pred=return_pred)
 
-        loss_tensor = loss_tensor / steps_between_backprops
+        loss_tensor = loss_tensor / batches_between_backprops
         loss_tensor.backward()
         callback.on_backward_end(step)
 

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -330,8 +330,7 @@ class Model:
                                        validation_steps=validation_steps,
                                        initial_epoch=initial_epoch,
                                        callback=callback_list,
-                                       metrics_names=self.metrics_names,
-                                       batches_per_step=batches_per_step)
+                                       metrics_names=self.metrics_names)
 
         for train_step_iterator, valid_step_iterator in epoch_iterator:
             with self._set_training_mode(True):

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -145,7 +145,8 @@ class Model:
             validation_steps=None,
             initial_epoch=1,
             verbose=True,
-            callbacks=None):
+            callbacks=None,
+            batches_between_backprops=1):
         # pylint: disable=line-too-long
         # pylint: disable=too-many-arguments
         """
@@ -184,6 +185,10 @@ class Model:
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called
                 during training.
                 (Default value = None)
+            batches_between_backprops (int): Number of batches on which to compute the running loss before 
+                backpropagating it through the network. Note that the total loss used for backpropagation is
+                the mean of the `batches_between_backprops` batch losses.
+                (Default value = 1)
 
         Returns:
             List of dict containing the history of each epoch.
@@ -219,7 +224,8 @@ class Model:
                                   validation_steps=validation_steps,
                                   initial_epoch=initial_epoch,
                                   verbose=verbose,
-                                  callbacks=callbacks)
+                                  callbacks=callbacks,
+                                  batches_between_backprops=batches_between_backprops)
 
     def _dataloader_from_data(self, args, batch_size):
         args = numpy_to_torch(args)

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -146,7 +146,7 @@ class Model:
             initial_epoch=1,
             verbose=True,
             callbacks=None,
-            batches_between_backprops=1):
+            batches_per_step=1):
         # pylint: disable=line-too-long
         # pylint: disable=too-many-arguments
         """
@@ -185,9 +185,9 @@ class Model:
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called
                 during training.
                 (Default value = None)
-            batches_between_backprops (int): Number of batches on which to compute the running loss before
+            batches_per_step (int): Number of batches on which to compute the running loss before
                 backpropagating it through the network. Note that the total loss used for backpropagation is
-                the mean of the `batches_between_backprops` batch losses.
+                the mean of the `batches_per_step` batch losses.
                 (Default value = 1)
 
         Returns:
@@ -225,7 +225,7 @@ class Model:
                                   initial_epoch=initial_epoch,
                                   verbose=verbose,
                                   callbacks=callbacks,
-                                  batches_between_backprops=batches_between_backprops)
+                                  batches_per_step=batches_per_step)
 
     def _dataloader_from_data(self, args, batch_size):
         args = numpy_to_torch(args)
@@ -243,7 +243,7 @@ class Model:
                       initial_epoch=1,
                       verbose=True,
                       callbacks=None,
-                      batches_between_backprops=1):
+                      batches_per_step=1):
         # pylint: disable=too-many-locals, line-too-long
         """
         Trains the model on a dataset using a generator.
@@ -286,9 +286,9 @@ class Model:
                 (Default value = True)
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called during training.
                 (Default value = None)
-            batches_between_backprops (int): Number of batches on which to compute the running loss before
+            batches_per_step (int): Number of batches on which to compute the running loss before
                 backpropagating it through the network. Note that the total loss used for backpropagation is
-                the mean of the `batches_between_backprops` batch losses.
+                the mean of the `batches_per_step` batch losses.
                 (Default value = 1)
 
         Returns:
@@ -330,7 +330,7 @@ class Model:
                                        initial_epoch=initial_epoch,
                                        callback=callback_list,
                                        metrics_names=self.metrics_names,
-                                       batches_between_backprops=batches_between_backprops)
+                                       batches_per_step=batches_per_step)
 
         for train_step_iterator, valid_step_iterator in epoch_iterator:
             with self._set_training_mode(True):
@@ -341,7 +341,7 @@ class Model:
                                                                  step=step.number,
                                                                  zero_all_gradients=step.zero_all_gradients,
                                                                  do_backprop=step.do_backprop,
-                                                                 batches_between_backprops=batches_between_backprops)
+                                                                 batches_per_step=batches_per_step)
                     step.size = self._get_batch_size(x, y)
 
             if valid_step_iterator is not None:
@@ -360,7 +360,7 @@ class Model:
                    return_pred=False,
                    zero_all_gradients=True,
                    do_backprop=True,
-                   batches_between_backprops=1):
+                   batches_per_step=1):
         if zero_all_gradients:
             self.optimizer.zero_grad()
 
@@ -369,7 +369,7 @@ class Model:
                                                                       return_loss_tensor=True,
                                                                       return_pred=return_pred)
 
-        loss_tensor = loss_tensor / batches_between_backprops
+        loss_tensor = loss_tensor / batches_per_step
         loss_tensor.backward()
         callback.on_backward_end(step)
 

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -374,6 +374,7 @@ class Model:
                    do_backprop=True,
                    batch_size=None,
                    examples_in_step=None):
+        # pylint: disable=too-many-locals
         if zero_all_gradients:
             self.optimizer.zero_grad()
 

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -223,10 +223,10 @@ class Model:
                                   epochs=epochs,
                                   steps_per_epoch=steps_per_epoch,
                                   validation_steps=validation_steps,
+                                  batches_per_step=batches_per_step,
                                   initial_epoch=initial_epoch,
                                   verbose=verbose,
-                                  callbacks=callbacks,
-                                  batches_per_step=batches_per_step)
+                                  callbacks=callbacks)
 
     def _dataloader_from_data(self, args, batch_size):
         args = numpy_to_torch(args)

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -185,7 +185,7 @@ class Model:
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called
                 during training.
                 (Default value = None)
-            batches_between_backprops (int): Number of batches on which to compute the running loss before 
+            batches_between_backprops (int): Number of batches on which to compute the running loss before
                 backpropagating it through the network. Note that the total loss used for backpropagation is
                 the mean of the `batches_between_backprops` batch losses.
                 (Default value = 1)
@@ -286,7 +286,7 @@ class Model:
                 (Default value = True)
             callbacks (list of poutyne.framework.Callback): List of callbacks that will be called during training.
                 (Default value = None)
-            batches_between_backprops (int): Number of batches on which to compute the running loss before 
+            batches_between_backprops (int): Number of batches on which to compute the running loss before
                 backpropagating it through the network. Note that the total loss used for backpropagation is
                 the mean of the `batches_between_backprops` batch losses.
                 (Default value = 1)

--- a/poutyne/framework/model.py
+++ b/poutyne/framework/model.py
@@ -336,12 +336,15 @@ class Model:
         for train_step_iterator, valid_step_iterator in epoch_iterator:
             with self._set_training_mode(True):
                 for step, (x, y) in train_step_iterator:
+                    zero_all_gradients = ((step.number - 1) % batches_per_step == 0)
+                    do_backprop = (step.number % batches_per_step == 0) or (step.number == steps_per_epoch)
+
                     step.loss, step.metrics, _ = self._fit_batch(x,
                                                                  y,
                                                                  callback=callback_list,
                                                                  step=step.number,
-                                                                 zero_all_gradients=step.zero_all_gradients,
-                                                                 do_backprop=step.do_backprop,
+                                                                 zero_all_gradients=zero_all_gradients,
+                                                                 do_backprop=do_backprop,
                                                                  batches_per_step=batches_per_step)
                     step.size = self._get_batch_size(x, y)
 

--- a/tests/framework/test_model.py
+++ b/tests/framework/test_model.py
@@ -4,13 +4,13 @@ import unittest
 from unittest import TestCase, skipIf
 from unittest.mock import MagicMock, call, ANY
 
+from math import ceil
 import numpy as np
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
-from math import ceil
 from poutyne.utils import TensorDataset
 from poutyne.framework import Model
 from poutyne.framework import warning_settings

--- a/tests/framework/test_model.py
+++ b/tests/framework/test_model.py
@@ -278,7 +278,6 @@ class ModelTest(TestCase):
         self.assertEqual(1, self.mocked_optimizer.step.call_count)
         self.assertEqual(1, self.mocked_optimizer.zero_grad.call_count)
 
-
     def test_correct_optim_calls__valid_n_batches_per_step(self):
         n_batches = 5
         items_per_batch = int(ModelTest.batch_size / n_batches)
@@ -286,10 +285,7 @@ class ModelTest(TestCase):
         x = torch.rand(n_batches, items_per_batch, 1)
         y = torch.rand(n_batches, items_per_batch, 1)
 
-        _ = self.mocked_optim_model.fit_generator(list(zip(x, y)),
-                                                  None,
-                                                  epochs=1,
-                                                  batches_per_step=n_batches)
+        _ = self.mocked_optim_model.fit_generator(list(zip(x, y)), None, epochs=1, batches_per_step=n_batches)
 
         self.assertEqual(1, self.mocked_optimizer.step.call_count)
         self.assertEqual(1, self.mocked_optimizer.zero_grad.call_count)
@@ -302,10 +298,7 @@ class ModelTest(TestCase):
 
         initial_params = self.model.get_weight_copies()
 
-        self.model.fit_generator(list(zip(x, y)),
-                                 None,
-                                 epochs=1,
-                                 batches_per_step=1)
+        self.model.fit_generator(list(zip(x, y)), None, epochs=1, batches_per_step=1)
 
         expected_params = list(self.model.get_weight_copies().values())
 
@@ -317,10 +310,7 @@ class ModelTest(TestCase):
             x.resize_((n_batches_per_step, mini_batch_size, 1))
             y.resize_((n_batches_per_step, mini_batch_size, 1))
 
-            self.model.fit_generator(list(zip(x, y)),
-                                     None,
-                                     epochs=1,
-                                     batches_per_step=n_batches_per_step)
+            self.model.fit_generator(list(zip(x, y)), None, epochs=1, batches_per_step=n_batches_per_step)
 
             returned_params = list(self.model.get_weight_copies().values())
 

--- a/tests/framework/test_model.py
+++ b/tests/framework/test_model.py
@@ -317,6 +317,25 @@ class ModelTest(TestCase):
 
             np.testing.assert_almost_equal(returned_params, expected_params, decimal=4)
 
+    def test_fitting_generator_n_batches_per_step_higher_than_num_batches(self):
+        total_batch_size = 6
+
+        x = torch.rand(1, total_batch_size, 1)
+        y = torch.rand(1, total_batch_size, 1)
+
+        initial_params = self.model.get_weight_copies()
+
+        self.model.fit_generator(list(zip(x, y)), None, epochs=1, batches_per_step=1)
+
+        expected_params = list(self.model.get_weight_copies().values())
+
+        self.model.set_weights(initial_params)
+
+        self.model.fit_generator(list(zip(x, y)), None, epochs=1, batches_per_step=2)
+
+        returned_params = list(self.model.get_weight_copies().values())
+
+        np.testing.assert_almost_equal(returned_params, expected_params, decimal=4)
 
     def test_fitting_generator_n_batches_per_step_uneven_batches(self):
         total_batch_size = 6
@@ -341,7 +360,7 @@ class ModelTest(TestCase):
             splitted_x = x.split(chunk_size)
             splitted_y = y.split(chunk_size)
 
-            n_batches_per_step = ceil(total_batch_size/chunk_size)
+            n_batches_per_step = ceil(total_batch_size / chunk_size)
 
             self.model.fit_generator(list(zip(splitted_x, splitted_y)),
                                      None,

--- a/tests/framework/test_model.py
+++ b/tests/framework/test_model.py
@@ -273,7 +273,7 @@ class ModelTest(TestCase):
                                                   None,
                                                   epochs=1,
                                                   steps_per_epoch=1,
-                                                  batches_between_backprops=1)
+                                                  batches_per_step=1)
 
         self.assertEqual(1, self.mocked_optimizer.step.call_count)
         self.assertEqual(1, self.mocked_optimizer.zero_grad.call_count)
@@ -289,12 +289,12 @@ class ModelTest(TestCase):
         _ = self.mocked_optim_model.fit_generator(list(zip(x, y)),
                                                   None,
                                                   epochs=1,
-                                                  batches_between_backprops=n_batches)
+                                                  batches_per_step=n_batches)
 
         self.assertEqual(1, self.mocked_optimizer.step.call_count)
         self.assertEqual(1, self.mocked_optimizer.zero_grad.call_count)
 
-    def test_fitting_generator_n_batches_between_backprops(self):
+    def test_fitting_generator_n_batches_per_step(self):
         total_batch_size = 6
 
         x = torch.rand(1, total_batch_size, 1)
@@ -305,22 +305,22 @@ class ModelTest(TestCase):
         self.model.fit_generator(list(zip(x, y)),
                                  None,
                                  epochs=1,
-                                 batches_between_backprops=1)
+                                 batches_per_step=1)
 
         expected_params = list(self.model.get_weight_copies().values())
 
         for mini_batch_size in [1, 2, 5]:
             self.model.set_weights(initial_params)
 
-            n_batches_between_backprops = int(total_batch_size / mini_batch_size)
+            n_batches_per_step = int(total_batch_size / mini_batch_size)
 
-            x.resize_((n_batches_between_backprops, mini_batch_size, 1))
-            y.resize_((n_batches_between_backprops, mini_batch_size, 1))
+            x.resize_((n_batches_per_step, mini_batch_size, 1))
+            y.resize_((n_batches_per_step, mini_batch_size, 1))
 
             self.model.fit_generator(list(zip(x, y)),
                                      None,
                                      epochs=1,
-                                     batches_between_backprops=n_batches_between_backprops)
+                                     batches_per_step=n_batches_per_step)
 
             returned_params = list(self.model.get_weight_copies().values())
 


### PR DESCRIPTION
With this PR, one can now compute a running loss on multiple batches before proceeding with a weight upgrade, essentially allowing to train a NN on a batch size too big to fit within a GPU's memory by simply fitting multiple smaller batches before upgrading the weights.

Please note that, according to a given parameter `batches_per_step`, the current implementation will divide the running loss of all `batches_per_step` by `batches_per_step`, making the total loss used for the backpropagation an average of the losses on the desired previous batches. This only makes sense in case of losses which are already averaged along the batch size, instead of summed per example. However, since most losses are averaged by default over a given batch, I believe it makes sense to use this out of the box.