### PR TITLE
Reorganize doc tree

### DIFF
--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -2,7 +2,7 @@
     :class: hidden-section
 
 Callbacks
-===========================
+=========
 
 .. automodule:: poutyne
 .. currentmodule:: poutyne.framework.callbacks

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -1,7 +1,7 @@
 .. role:: hidden
     :class: hidden-section
 
-poutyne.framework.callbacks
+Callbacks
 ===========================
 
 .. automodule:: poutyne

--- a/docs/source/experiment.rst
+++ b/docs/source/experiment.rst
@@ -2,7 +2,7 @@
     :class: hidden-section
 
 Experiment
-==================================================
+==========
 
 .. warning:: This class is still in Beta phase. It may well be considerably modified in near future.
 

--- a/docs/source/experiment.rst
+++ b/docs/source/experiment.rst
@@ -1,7 +1,7 @@
 .. role:: hidden
     :class: hidden-section
 
-poutyne.framework.Experiment
+Experiment
 ==================================================
 
 .. warning:: This class is still in Beta phase. It may well be considerably modified in near future.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -168,12 +168,12 @@ API Reference
   :maxdepth: 1
   :caption: Package Reference
 
-  utils
   model
   experiment
   metrics
   callbacks
   layers
+  utils
 
 
 Indices and tables

--- a/docs/source/layers.rst
+++ b/docs/source/layers.rst
@@ -1,14 +1,11 @@
 .. role:: hidden
     :class: hidden-section
 
-poutyne.layers
+Layers
 ==============
 
 .. automodule:: poutyne
 .. currentmodule:: poutyne.layers
-
-Layers
-------
 
 Poutyne provides utility layers that can be used with the ``Sequential`` module,
 ``ModuleList`` module and others.

--- a/docs/source/layers.rst
+++ b/docs/source/layers.rst
@@ -2,7 +2,7 @@
     :class: hidden-section
 
 Layers
-==============
+======
 
 .. automodule:: poutyne
 .. currentmodule:: poutyne.layers

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -1,7 +1,7 @@
 .. role:: hidden
     :class: hidden-section
 
-poutyne.framework.metrics
+Metrics
 ===========================
 
 .. automodule:: poutyne

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -2,7 +2,7 @@
     :class: hidden-section
 
 Metrics
-===========================
+=======
 
 .. automodule:: poutyne
 .. currentmodule:: poutyne.framework.metrics

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -2,7 +2,7 @@
     :class: hidden-section
 
 Model
-==================================================
+=====
 
 .. automodule:: poutyne
 .. currentmodule:: poutyne.framework

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -1,7 +1,7 @@
 .. role:: hidden
     :class: hidden-section
 
-poutyne.framework.Model
+Model
 ==================================================
 
 .. automodule:: poutyne

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,14 +1,11 @@
 .. role:: hidden
     :class: hidden-section
 
-poutyne
-=======
+Utils
+=====
 
 .. automodule:: poutyne
 .. currentmodule:: poutyne
-
-Utils
------
 
 These utils functions only support the following basic Python types: tuple,
 list and dict.


### PR DESCRIPTION
The leftside list of Poutyne elements on the documentation website is now updated to be more elegent (i.e. poutyne.framework.model becomes Model).

Also reordered the elements in pertinence order.