### PR TITLE
unnecessary code line in experiment

### DIFF
--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -457,7 +457,6 @@ class Experiment:
         # Copy callback list.
         callbacks = list(callbacks)
 
-        tensorboard_writer = None
         initial_epoch = 1
         if self.logging:
             if not os.path.exists(self.directory):


### PR DESCRIPTION
This None affectation is unnecessary since `_init_tensorboard_callbacks` return a None if `SummaryWriter` is not present.