### PR TITLE
Change naming of batch and epoch in callbacks

### DIFF
--- a/poutyne/framework/callbacks/best_model_restore.py
+++ b/poutyne/framework/callbacks/best_model_restore.py
@@ -33,13 +33,13 @@ class BestModelRestore(Callback):
         self.best_weights = None
         self.verbose = verbose
 
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         if self.monitor_op(logs[self.monitor], self.current_best):
             old_best = self.current_best
             self.current_best = logs[self.monitor]
 
             if self.verbose:
-                print('Epoch %d: %s improved from %0.5f to %0.5f' % (epoch, self.monitor, old_best, self.current_best))
+                print('Epoch %d: %s improved from %0.5f to %0.5f' % (epoch_number, self.monitor, old_best, self.current_best))
             self.best_weights = self.model.get_weight_copies()
 
     def on_train_end(self, logs):

--- a/poutyne/framework/callbacks/best_model_restore.py
+++ b/poutyne/framework/callbacks/best_model_restore.py
@@ -39,7 +39,8 @@ class BestModelRestore(Callback):
             self.current_best = logs[self.monitor]
 
             if self.verbose:
-                print('Epoch %d: %s improved from %0.5f to %0.5f' % (epoch_number, self.monitor, old_best, self.current_best))
+                print('Epoch %d: %s improved from %0.5f to %0.5f' %
+                      (epoch_number, self.monitor, old_best, self.current_best))
             self.best_weights = self.model.get_weight_copies()
 
     def on_train_end(self, logs):

--- a/poutyne/framework/callbacks/callbacks.py
+++ b/poutyne/framework/callbacks/callbacks.py
@@ -59,29 +59,29 @@ class CallbackList:
         for callback in self.callbacks:
             callback.set_model(model)
 
-    def on_epoch_begin(self, epoch, logs=None):
+    def on_epoch_begin(self, epoch_number, logs=None):
         logs = logs or {}
         for callback in self.callbacks:
-            callback.on_epoch_begin(epoch, logs)
+            callback.on_epoch_begin(epoch_number, logs)
 
-    def on_epoch_end(self, epoch, logs=None):
+    def on_epoch_end(self, epoch_number, logs=None):
         logs = logs or {}
         for callback in self.callbacks:
-            callback.on_epoch_end(epoch, logs)
+            callback.on_epoch_end(epoch_number, logs)
 
-    def on_batch_begin(self, batch, logs=None):
+    def on_batch_begin(self, batch_number, logs=None):
         logs = logs or {}
         for callback in self.callbacks:
-            callback.on_batch_begin(batch, logs)
+            callback.on_batch_begin(batch_number, logs)
 
-    def on_batch_end(self, batch, logs=None):
+    def on_batch_end(self, batch_number, logs=None):
         logs = logs or {}
         for callback in self.callbacks:
-            callback.on_batch_end(batch, logs)
+            callback.on_batch_end(batch_number, logs)
 
-    def on_backward_end(self, batch):
+    def on_backward_end(self, batch_number):
         for callback in self.callbacks:
-            callback.on_backward_end(batch)
+            callback.on_backward_end(batch_number)
 
     def on_train_begin(self, logs=None):
         logs = logs or {}
@@ -114,22 +114,22 @@ class Callback:
     def set_model(self, model):
         self.model = model
 
-    def on_epoch_begin(self, epoch, logs):
+    def on_epoch_begin(self, epoch_number, logs):
         """
         Is called before the begining of each epoch.
 
         Args:
-            epoch (int): The epoch number.
+            epoch_number (int): The epoch number.
             logs (dict): Usually an empty dict.
         """
         pass
 
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         """
         Is called before the end of each epoch.
 
         Args:
-            epoch (int): The epoch number.
+            epoch_number (int): The epoch number.
             logs (dict): Contains the following keys:
 
                  * 'epoch': The epoch number.
@@ -146,22 +146,22 @@ class Callback:
         """
         pass
 
-    def on_batch_begin(self, batch, logs):
+    def on_batch_begin(self, batch_number, logs):
         """
         Is called before the begining of each batch.
 
         Args:
-            batch (int): The batch number.
+            batch_number (int): The batch number.
             logs (dict): Usually an empty dict.
         """
         pass
 
-    def on_batch_end(self, batch, logs):
+    def on_batch_end(self, batch_number, logs):
         """
         Is called before the end of each batch.
 
         Args:
-            batch (int): The batch number.
+            batch_number (int): The batch number.
             logs (dict): Contains the following keys:
 
                  * 'batch': The batch number.
@@ -175,12 +175,12 @@ class Callback:
         """
         pass
 
-    def on_backward_end(self, batch):
+    def on_backward_end(self, batch_number):
         """
         Is called after the backpropagation but before the optimization step.
 
         Args:
-            batch (int): The batch number.
+            batch_number (int): The batch number.
         """
         pass
 

--- a/poutyne/framework/callbacks/checkpoint.py
+++ b/poutyne/framework/callbacks/checkpoint.py
@@ -25,7 +25,7 @@ class ModelCheckpoint(PeriodicSaveCallback):
         if self.restore_best and not self.save_best_only:
             raise ValueError("The 'restore_best' argument only works when 'save_best_only' is also true.")
 
-    def save_file(self, fd, epoch, logs):
+    def save_file(self, fd, epoch_number, logs):
         self.model.save_weights(fd)
 
     def on_train_end(self, logs):
@@ -53,7 +53,7 @@ class OptimizerCheckpoint(PeriodicSaveCallback):
         :class:`~poutyne.framework.callbacks.PeriodicSaveCallback`
     """
 
-    def save_file(self, fd, epoch, logs):
+    def save_file(self, fd, epoch_number, logs):
         self.model.save_optimizer_state(fd)
 
 
@@ -84,7 +84,7 @@ class LRSchedulerCheckpoint(PeriodicSaveCallback):
         if not isinstance(self.lr_scheduler, (_PyTorchLRSchedulerWrapper, ReduceLROnPlateau)):
             raise ValueError("Unknown scheduler callback '%s'." % lr_scheduler)
 
-    def save_file(self, fd, epoch, logs):
+    def save_file(self, fd, epoch_number, logs):
         self.lr_scheduler.save_state(fd)
 
     def set_params(self, params):
@@ -95,25 +95,25 @@ class LRSchedulerCheckpoint(PeriodicSaveCallback):
         self.lr_scheduler.set_model(model)
         super().set_model(model)
 
-    def on_epoch_begin(self, epoch, logs):
-        self.lr_scheduler.on_epoch_begin(epoch, logs)
-        super().on_epoch_begin(epoch, logs)
+    def on_epoch_begin(self, epoch_number, logs):
+        self.lr_scheduler.on_epoch_begin(epoch_number, logs)
+        super().on_epoch_begin(epoch_number, logs)
 
-    def on_epoch_end(self, epoch, logs):
-        self.lr_scheduler.on_epoch_end(epoch, logs)
-        super().on_epoch_end(epoch, logs)
+    def on_epoch_end(self, epoch_number, logs):
+        self.lr_scheduler.on_epoch_end(epoch_number, logs)
+        super().on_epoch_end(epoch_number, logs)
 
-    def on_batch_begin(self, batch, logs):
-        self.lr_scheduler.on_batch_begin(batch, logs)
-        super().on_batch_begin(batch, logs)
+    def on_batch_begin(self, batch_number, logs):
+        self.lr_scheduler.on_batch_begin(batch_number, logs)
+        super().on_batch_begin(batch_number, logs)
 
-    def on_batch_end(self, batch, logs):
-        self.lr_scheduler.on_batch_end(batch, logs)
-        super().on_batch_end(batch, logs)
+    def on_batch_end(self, batch_number, logs):
+        self.lr_scheduler.on_batch_end(batch_number, logs)
+        super().on_batch_end(batch_number, logs)
 
-    def on_backward_end(self, batch):
-        self.lr_scheduler.on_backward_end(batch)
-        super().on_backward_end(batch)
+    def on_backward_end(self, batch_number):
+        self.lr_scheduler.on_backward_end(batch_number)
+        super().on_backward_end(batch_number)
 
     def on_train_begin(self, logs):
         self.lr_scheduler.on_train_begin(logs)

--- a/poutyne/framework/callbacks/clip_grad.py
+++ b/poutyne/framework/callbacks/clip_grad.py
@@ -19,7 +19,7 @@ class ClipNorm(Callback):
         self.max_norm = max_norm
         self.norm_type = norm_type
 
-    def on_backward_end(self, batch):
+    def on_backward_end(self, batch_number):
         clip_grad_norm_(self.parameters, self.max_norm, norm_type=self.norm_type)
 
 
@@ -38,5 +38,5 @@ class ClipValue(Callback):
         self.parameters = list(parameters)
         self.clip_value = clip_value
 
-    def on_backward_end(self, batch):
+    def on_backward_end(self, batch_number):
         clip_grad_value_(self.parameters, self.clip_value)

--- a/poutyne/framework/callbacks/delay.py
+++ b/poutyne/framework/callbacks/delay.py
@@ -33,31 +33,31 @@ class DelayCallback(Callback):
     def set_model(self, model):
         self.callbacks.set_model(model)
 
-    def on_epoch_begin(self, epoch, logs):
-        self.current_epoch = epoch
+    def on_epoch_begin(self, epoch_number, logs):
+        self.current_epoch = epoch_number
         if self.has_delay_passed():
             self.has_on_epoch_begin_been_called = True
-            self.callbacks.on_epoch_begin(epoch, logs)
+            self.callbacks.on_epoch_begin(epoch_number, logs)
 
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         if self.has_delay_passed():
-            self.callbacks.on_epoch_end(epoch, logs)
+            self.callbacks.on_epoch_end(epoch_number, logs)
 
-    def on_batch_begin(self, batch, logs):
+    def on_batch_begin(self, batch_number, logs):
         self.batch_counter += 1
         if self.has_delay_passed():
             if not self.has_on_epoch_begin_been_called:
                 self.has_on_epoch_begin_been_called = True
                 self.callbacks.on_epoch_begin(self.current_epoch, logs)
-            self.callbacks.on_batch_begin(batch, logs)
+            self.callbacks.on_batch_begin(batch_number, logs)
 
-    def on_batch_end(self, batch, logs):
+    def on_batch_end(self, batch_number, logs):
         if self.has_delay_passed():
-            self.callbacks.on_batch_end(batch, logs)
+            self.callbacks.on_batch_end(batch_number, logs)
 
-    def on_backward_end(self, batch):
+    def on_backward_end(self, batch_number):
         if self.has_delay_passed():
-            self.callbacks.on_backward_end(batch)
+            self.callbacks.on_backward_end(batch_number)
 
     def on_train_begin(self, logs):
         self.current_epoch = 0

--- a/poutyne/framework/callbacks/earlystopping.py
+++ b/poutyne/framework/callbacks/earlystopping.py
@@ -95,7 +95,7 @@ class EarlyStopping(Callback):
         self.stopped_epoch = 0
         self.best = np.Inf if self.mode == 'min' else -np.Inf
 
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         current = logs[self.monitor]
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current
@@ -103,7 +103,7 @@ class EarlyStopping(Callback):
         else:
             self.wait += 1
             if self.wait >= self.patience:
-                self.stopped_epoch = epoch
+                self.stopped_epoch = epoch_number
                 self.model.stop_training = True
 
     def on_train_end(self, logs):

--- a/poutyne/framework/callbacks/logger.py
+++ b/poutyne/framework/callbacks/logger.py
@@ -7,15 +7,15 @@ class Logger(Callback):
     def __init__(self, *, batch_granularity=False):
         super().__init__()
         self.batch_granularity = batch_granularity
-        self.epoch = 0
+        self.epoch_number = 0
 
     def on_train_begin(self, logs):
         metrics = ['loss'] + self.model.metrics_names
 
         if self.batch_granularity:
-            self.fieldnames = ['epoch', 'batch', 'size', 'time', 'lr']
+            self.fieldnames = ['epoch_number', 'batch', 'size', 'time', 'lr']
         else:
-            self.fieldnames = ['epoch', 'time', 'lr']
+            self.fieldnames = ['epoch_number', 'time', 'lr']
         self.fieldnames += metrics
         self.fieldnames += ['val_' + metric for metric in metrics]
         self._on_train_begin_write(logs)
@@ -31,18 +31,18 @@ class Logger(Callback):
     def _on_batch_end_write(self, batch_number, logs):
         pass
 
-    def on_epoch_begin(self, epoch, logs):
-        self.epoch = epoch
-        self._on_epoch_begin_write(epoch, logs)
+    def on_epoch_begin(self, epoch_number, logs):
+        self.epoch_number = epoch_number
+        self._on_epoch_begin_write(epoch_number, logs)
 
-    def _on_epoch_begin_write(self, epoch, logs):
+    def _on_epoch_begin_write(self, epoch_number, logs):
         pass
 
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         logs = self._get_logs_without_unknown_keys(logs)
-        self._on_epoch_end_write(epoch, logs)
+        self._on_epoch_end_write(epoch_number, logs)
 
-    def _on_epoch_end_write(self, epoch, logs):
+    def _on_epoch_end_write(self, epoch_number, logs):
         pass
 
     def on_train_end(self, logs=None):
@@ -61,7 +61,7 @@ class Logger(Callback):
 
 class CSVLogger(Logger):
     """
-    Callback that outputs the result of each epoch or batch into a CSV file.
+    Callback that outputs the result of each epoch_number or batch into a CSV file.
 
     Args:
         filename (str): The filename of the CSV.
@@ -91,7 +91,7 @@ class CSVLogger(Logger):
         self.writer.writerow(logs)
         self.csvfile.flush()
 
-    def _on_epoch_end_write(self, epoch, logs):
+    def _on_epoch_end_write(self, epoch_number, logs):
         self.writer.writerow(dict(logs, lr=self._get_current_learning_rates()))
         self.csvfile.flush()
 
@@ -101,7 +101,7 @@ class CSVLogger(Logger):
 
 class TensorBoardLogger(Logger):
     """
-    Callback that outputs the result of each epoch or batch into a Tensorboard experiment folder.
+    Callback that outputs the result of each epoch_number or batch into a Tensorboard experiment folder.
 
     Args:
         writer (~torch.utils.tensorboard.writer.SummaryWriter): The tensorboard writer.
@@ -133,7 +133,7 @@ class TensorBoardLogger(Logger):
         """
         pass
 
-    def _on_epoch_end_write(self, epoch, logs):
+    def _on_epoch_end_write(self, epoch_number, logs):
         grouped_items = dict()
         for k, v in logs.items():
             if 'val_' in k:
@@ -146,9 +146,9 @@ class TensorBoardLogger(Logger):
                     grouped_items[k] = dict()
                 grouped_items[k][k] = v
         for k, v in grouped_items.items():
-            self.writer.add_scalars(k, v, epoch)
+            self.writer.add_scalars(k, v, epoch_number)
         lr = self._get_current_learning_rates()
         if isinstance(lr, (list, )):
-            self.writer.add_scalars('lr', {str(i): v for i, v in enumerate(lr)}, epoch)
+            self.writer.add_scalars('lr', {str(i): v for i, v in enumerate(lr)}, epoch_number)
         else:
-            self.writer.add_scalars('lr', {'lr': lr}, epoch)
+            self.writer.add_scalars('lr', {'lr': lr}, epoch_number)

--- a/poutyne/framework/callbacks/logger.py
+++ b/poutyne/framework/callbacks/logger.py
@@ -150,5 +150,5 @@ class TensorBoardLogger(Logger):
         else:
             self.writer.add_scalars('lr', {'lr': lr}, epoch_number)
 
-    def on_train_end(self, logs=None):
+    def _on_train_end_write(self, logs=None):
         self.writer.close()

--- a/poutyne/framework/callbacks/logger.py
+++ b/poutyne/framework/callbacks/logger.py
@@ -149,3 +149,6 @@ class TensorBoardLogger(Logger):
             self.writer.add_scalars('lr', {str(i): v for i, v in enumerate(lr)}, epoch_number)
         else:
             self.writer.add_scalars('lr', {'lr': lr}, epoch_number)
+
+    def on_train_end(self, logs=None):
+        self.writer.close()

--- a/poutyne/framework/callbacks/logger.py
+++ b/poutyne/framework/callbacks/logger.py
@@ -33,7 +33,7 @@ class Logger(Callback):
 
     def on_epoch_begin(self, epoch_number, logs):
         self.epoch_number = epoch_number
-        self._on_epoch_begin_write(epoch_number, logs)
+        self._on_epoch_begin_write(self.epoch_number, logs)
 
     def _on_epoch_begin_write(self, epoch_number, logs):
         pass

--- a/poutyne/framework/callbacks/logger.py
+++ b/poutyne/framework/callbacks/logger.py
@@ -1,4 +1,5 @@
 import csv
+
 from .callbacks import Callback
 
 
@@ -22,12 +23,12 @@ class Logger(Callback):
     def _on_train_begin_write(self, logs):
         pass
 
-    def on_batch_end(self, batch, logs):
+    def on_batch_end(self, batch_number, logs):
         if self.batch_granularity:
             logs = self._get_logs_without_unknown_keys(logs)
-            self._on_batch_end_write(batch, logs)
+            self._on_batch_end_write(batch_number, logs)
 
-    def _on_batch_end_write(self, batch, logs):
+    def _on_batch_end_write(self, batch_number, logs):
         pass
 
     def on_epoch_begin(self, epoch, logs):
@@ -86,7 +87,7 @@ class CSVLogger(Logger):
             self.writer.writeheader()
             self.csvfile.flush()
 
-    def _on_batch_end_write(self, batch, logs):
+    def _on_batch_end_write(self, batch_number, logs):
         self.writer.writerow(logs)
         self.csvfile.flush()
 
@@ -123,7 +124,10 @@ class TensorBoardLogger(Logger):
         super().__init__(batch_granularity=False)
         self.writer = writer
 
-    def _on_batch_end_write(self, batch, logs):
+    def on_batch_end(self, batch_number, logs):
+        self._on_batch_end_write(batch_number, logs)
+
+    def _on_batch_end_write(self, batch_number, logs):
         """
         We don't handle tensorboard writing on batch granularity
         """

--- a/poutyne/framework/callbacks/logger.py
+++ b/poutyne/framework/callbacks/logger.py
@@ -124,9 +124,6 @@ class TensorBoardLogger(Logger):
         super().__init__(batch_granularity=False)
         self.writer = writer
 
-    def on_batch_end(self, batch_number, logs):
-        self._on_batch_end_write(batch_number, logs)
-
     def _on_batch_end_write(self, batch_number, logs):
         """
         We don't handle tensorboard writing on batch granularity

--- a/poutyne/framework/callbacks/logger.py
+++ b/poutyne/framework/callbacks/logger.py
@@ -13,9 +13,9 @@ class Logger(Callback):
         metrics = ['loss'] + self.model.metrics_names
 
         if self.batch_granularity:
-            self.fieldnames = ['epoch_number', 'batch', 'size', 'time', 'lr']
+            self.fieldnames = ['epoch', 'batch', 'size', 'time', 'lr']
         else:
-            self.fieldnames = ['epoch_number', 'time', 'lr']
+            self.fieldnames = ['epoch', 'time', 'lr']
         self.fieldnames += metrics
         self.fieldnames += ['val_' + metric for metric in metrics]
         self._on_train_begin_write(logs)

--- a/poutyne/framework/callbacks/lr_scheduler.py
+++ b/poutyne/framework/callbacks/lr_scheduler.py
@@ -30,8 +30,8 @@ class _PyTorchLRSchedulerWrapper(Callback):
         self.state_to_load = None
         self.torch_lr_scheduler = torch_lr_scheduler
 
-    def on_epoch_end(self, epoch, logs):
-        self.scheduler.step(epoch)
+    def on_epoch_end(self, epoch_number, logs):
+        self.scheduler.step(epoch_number)
 
     def on_train_begin(self, logs):
         self.scheduler = self.torch_lr_scheduler(self.model.optimizer, *self.args, **self.kwargs)
@@ -87,5 +87,5 @@ class ReduceLROnPlateau(_PyTorchLRSchedulerWrapper):
         super().__init__(torch_lr_scheduler=torch.optim.lr_scheduler.ReduceLROnPlateau, *args, **kwargs)
         self.monitor = monitor
 
-    def on_epoch_end(self, epoch, logs):
-        self.scheduler.step(logs[self.monitor], epoch)
+    def on_epoch_end(self, epoch_number, logs):
+        self.scheduler.step(logs[self.monitor], epoch_number)

--- a/poutyne/framework/callbacks/periodic.py
+++ b/poutyne/framework/callbacks/periodic.py
@@ -123,10 +123,10 @@ class PeriodicSaveCallback(Callback):
 
         self.period = period
 
-    def save_file(self, fd, epoch, logs):
+    def save_file(self, fd, epoch_number, logs):
         raise NotImplementedError
 
-    def _save_file(self, filename, epoch, logs):
+    def _save_file(self, filename, epoch_number, logs):
         if self.atomic_write:
             fd = None
             if self.temporary_filename is not None:
@@ -137,7 +137,7 @@ class PeriodicSaveCallback(Callback):
                 tmp_filename = fd.name
 
             with fd:
-                self.save_file(fd, epoch, logs)
+                self.save_file(fd, epoch_number, logs)
 
             try:
                 os.replace(tmp_filename, filename)
@@ -151,12 +151,12 @@ class PeriodicSaveCallback(Callback):
 
                 warnings.warn('Saving %s non-atomically instead.' % filename)
                 with open(filename, self.open_mode) as fd:
-                    self.save_file(fd, epoch, logs)
+                    self.save_file(fd, epoch_number, logs)
         else:
             with open(filename, self.open_mode) as fd:
-                self.save_file(fd, epoch, logs)
+                self.save_file(fd, epoch_number, logs)
 
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         filename = self.filename.format_map(logs)
 
         if self.save_best_only:
@@ -167,12 +167,12 @@ class PeriodicSaveCallback(Callback):
 
                 if self.verbose:
                     print('Epoch %d: %s improved from %0.5f to %0.5f, saving file to %s' %
-                          (epoch, self.monitor, old_best, self.current_best, self.best_filename))
-                self._save_file(self.best_filename, epoch, logs)
-        elif epoch % self.period == 0:
+                          (epoch_number, self.monitor, old_best, self.current_best, self.best_filename))
+                self._save_file(self.best_filename, epoch_number, logs)
+        elif epoch_number % self.period == 0:
             if self.verbose:
-                print('Epoch %d: saving file to %s' % (epoch, filename))
-            self._save_file(filename, epoch, logs)
+                print('Epoch %d: saving file to %s' % (epoch_number, filename))
+            self._save_file(filename, epoch_number, logs)
 
 
 class PeriodicSaveLambda(PeriodicSaveCallback):
@@ -192,5 +192,5 @@ class PeriodicSaveLambda(PeriodicSaveCallback):
         super().__init__(*args, **kwargs)
         self.func = func
 
-    def save_file(self, fd, epoch, logs):
-        self.func(fd, epoch, logs)
+    def save_file(self, fd, epoch_number, logs):
+        self.func(fd, epoch_number, logs)

--- a/poutyne/framework/callbacks/policies.py
+++ b/poutyne/framework/callbacks/policies.py
@@ -233,7 +233,7 @@ class OptimizerPolicy(Callback):
         self.current_step = initial_step
         self.phases_iter = iter(self)
 
-    def on_batch_begin(self, batch, logs):
+    def on_batch_begin(self, batch_number, logs):
         # Don't do anything when we run out of phases.
         with contextlib.suppress(StopIteration):
             spec = next(self.phases_iter)

--- a/poutyne/framework/callbacks/progress.py
+++ b/poutyne/framework/callbacks/progress.py
@@ -14,43 +14,43 @@ class ProgressionCallback(Callback):
     def on_train_end(self, logs):
         pass
 
-    def on_epoch_begin(self, epoch, logs):
+    def on_epoch_begin(self, epoch_number, logs):
         self.step_times_sum = 0.
-        self.epoch = epoch
-        sys.stdout.write("\rEpoch %d/%d" % (self.epoch, self.epochs))
+        self.epoch_number = epoch_number
+        sys.stdout.write("\rEpoch %d/%d" % (self.epoch_number, self.epochs))
         sys.stdout.flush()
 
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         epoch_total_time = logs['time']
 
         metrics_str = self._get_metrics_string(logs)
         if self.steps is not None:
             print("\rEpoch %d/%d %.2fs Step %d/%d: %s" %
-                  (self.epoch, self.epochs, epoch_total_time, self.steps, self.steps, metrics_str))
+                  (self.epoch_number, self.epochs, epoch_total_time, self.steps, self.steps, metrics_str))
         else:
             print("\rEpoch %d/%d %.2fs: Step %d/%d: %s" %
-                  (self.epoch, self.epochs, epoch_total_time, self.last_step, self.last_step, metrics_str))
+                  (self.epoch_number, self.epochs, epoch_total_time, self.last_step, self.last_step, metrics_str))
 
-    def on_batch_begin(self, batch, logs):
+    def on_batch_begin(self, batch_number, logs):
         pass
 
-    def on_batch_end(self, batch, logs):
+    def on_batch_end(self, batch_number, logs):
         self.step_times_sum += logs['time']
 
         metrics_str = self._get_metrics_string(logs)
 
-        times_mean = self.step_times_sum / batch
+        times_mean = self.step_times_sum / batch_number
         if self.steps is not None:
-            remaining_time = times_mean * (self.steps - batch)
+            remaining_time = times_mean * (self.steps - batch_number)
 
             sys.stdout.write("\rEpoch %d/%d ETA %.0fs Step %d/%d: %s" %
-                             (self.epoch, self.epochs, remaining_time, batch, self.steps, metrics_str))
+                             (self.epoch_number, self.epochs, remaining_time, batch_number, self.steps, metrics_str))
             sys.stdout.flush()
         else:
             sys.stdout.write("\rEpoch %d/%d %.2fs/step Step %d: %s" %
-                             (self.epoch, self.epochs, times_mean, batch, metrics_str))
+                             (self.epoch_number, self.epochs, times_mean, batch_number, metrics_str))
             sys.stdout.flush()
-            self.last_step = batch
+            self.last_step = batch_number
 
     def _get_metrics_string(self, logs):
         train_metrics_str_gen = ('{}: {:f}'.format(k, logs[k]) for k in self.metrics if logs.get(k) is not None)

--- a/poutyne/framework/callbacks/terminate_on_nan.py
+++ b/poutyne/framework/callbacks/terminate_on_nan.py
@@ -8,8 +8,8 @@ class TerminateOnNaN(Callback):
     Stops the training when the loss is either `NaN` or `inf`.
     """
 
-    def on_batch_end(self, batch, logs):
+    def on_batch_end(self, batch_number, logs):
         loss = logs['loss']
         if np.isnan(loss) or np.isinf(loss):
-            print('Batch %d: Invalid loss, terminating training' % (batch))
+            print('Batch %d: Invalid loss, terminating training' % (batch_number))
             self.model.stop_training = True

--- a/tests/framework/callbacks/test_logger.py
+++ b/tests/framework/callbacks/test_logger.py
@@ -33,10 +33,10 @@ def some_data_generator(batch_size):
 
 
 class History(Callback):
-    def on_epoch_end(self, epoch, logs):
+    def on_epoch_end(self, epoch_number, logs):
         self.history.append(logs)
 
-    def on_batch_end(self, batch, logs):
+    def on_batch_end(self, batch_number, logs):
         self.history.append(logs)
 
     def on_train_begin(self, logs):


### PR DESCRIPTION
I think the naming batch is misleading since it's a more a `batch_number` more than the usual `batch` concept.