### PR TITLE
Case of a sequence

### DIFF
--- a/poutyne/framework/loss.py
+++ b/poutyne/framework/loss.py
@@ -1,0 +1,30 @@
+from torch.nn import CrossEntropyLoss
+
+
+class SequenceCrossEntropy:
+    """
+    Wrapper around the cross entropy loss for a padded sequence
+    """
+
+    def __init__(self, padding_value=0):
+        self.loss_fct = CrossEntropyLoss(ignore_index=padding_value)
+
+    def __call__(self, y_pred, y):
+        """
+        Flatten the sequence before passing it to the CrossEntropyLoss.
+
+        Args:
+            y_pred (~torch.Tensor): The prediction from a model.
+            y (~torch.Tensor or Union[~torch.Tensor, ~torch.Tensor]): The target.
+                ~torch.Tensor if only the target.
+                Union[~torch.Tensor, ~torch.Tensor] if the target and a mask used to mask the padded elements.
+
+        Returns:
+                The loss value
+        """
+        if isinstance(y, tuple):
+            y = y[0]
+
+        flatten_y_pred = y_pred.view(y_pred.shape[0] * y_pred.shape[1], -1)
+        flatten_y = y.view(y.shape[0] * y.shape[1])
+        return self.loss_fct(flatten_y_pred, flatten_y)

--- a/poutyne/framework/metrics/metrics.py
+++ b/poutyne/framework/metrics/metrics.py
@@ -65,6 +65,7 @@ def soft_margin(y_pred, y_true):
 
 
 def masked_acc(y_pred: tensor, y: tuple):
+    # pylint: disable=line-too-long
     """
     The masked accuracy for sequence. The mask is use to *remove* the padded value and not calculate the accuracy over these value.
 

--- a/poutyne/framework/metrics/metrics.py
+++ b/poutyne/framework/metrics/metrics.py
@@ -64,7 +64,7 @@ def soft_margin(y_pred, y_true):
     return F.soft_margin_loss(y_pred, y_true)
 
 
-def masked_acc(y_pred: tensor, y: tuple):
+def sequence_acc(y_pred: tensor, y: tuple):
     # pylint: disable=line-too-long
     """
     The masked accuracy for sequence. The mask is use to *remove* the padded value and not calculate the accuracy over these value.
@@ -117,8 +117,8 @@ all_losses_metrics_dict = dict(acc=acc,
                                bcewithlogits=bce_with_logits,
                                smoothl1=smooth_l1,
                                softmargin=soft_margin,
-                               maskedacc=masked_acc,
-                               sequenceacc=masked_acc)
+                               sequenceacc=sequence_acc,
+                               seqacc=sequence_acc)
 
 
 def get_loss_or_metric(loss_metric):

--- a/tests/framework/metrics/test_fscores.py
+++ b/tests/framework/metrics/test_fscores.py
@@ -140,7 +140,7 @@ class FBetaTest(TestCase):
 
         fbeta = FBeta()
         fbeta(predictions, (targets, mask))
-
+        # check value
         numpy.testing.assert_almost_equal(fbeta._pred_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
         numpy.testing.assert_almost_equal(fbeta._true_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
         numpy.testing.assert_almost_equal(fbeta._true_positive_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
@@ -153,7 +153,7 @@ class FBetaTest(TestCase):
 
         f1_sequence = F1Sequence(average='macro', padding_value=45)
         f1_sequence(predictions, (targets, mask))
-
+        # check value
         numpy.testing.assert_almost_equal(f1_sequence._pred_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
         numpy.testing.assert_almost_equal(f1_sequence._true_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
         numpy.testing.assert_almost_equal(f1_sequence._true_positive_sum.tolist(), [0.0, 1.0, 0.0, 0.0])

--- a/tests/framework/metrics/test_fscores.py
+++ b/tests/framework/metrics/test_fscores.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 import numpy
 import torch
 
-from poutyne.framework.metrics import FBeta
+from poutyne.framework.metrics import FBeta, F1Sequence
 
 
 class FBetaTest(TestCase):
@@ -145,6 +145,19 @@ class FBetaTest(TestCase):
         numpy.testing.assert_almost_equal(fbeta._true_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
         numpy.testing.assert_almost_equal(fbeta._true_positive_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
         numpy.testing.assert_almost_equal(fbeta._total_sum.tolist(), [1.0, 1.0, 1.0, 1.0])
+
+    def test_f1sequence_multiclass_micro_average_metric(self):
+        mask = torch.Tensor([[1, 0]])
+        predictions = torch.Tensor([[[0.2862, 0.3479, 0.1627, 0.2033], [0.2862, 0.3479, 0.1627, 0.2033]]])
+        targets = torch.Tensor([[1, 45]])
+
+        f1_sequence = F1Sequence(average='macro', padding_value=45)
+        f1_sequence(predictions, (targets, mask))
+
+        numpy.testing.assert_almost_equal(f1_sequence._pred_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
+        numpy.testing.assert_almost_equal(f1_sequence._true_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
+        numpy.testing.assert_almost_equal(f1_sequence._true_positive_sum.tolist(), [0.0, 1.0, 0.0, 0.0])
+        numpy.testing.assert_almost_equal(f1_sequence._total_sum.tolist(), [1.0, 1.0, 1.0, 1.0])
 
     def _compute(self, *args, **kwargs):
         fbeta = FBeta(*args, **kwargs)


### PR DESCRIPTION
# Metric and loss in the specific case of a sequence

In the specific case of a sequence, there is minor change to be made to calculate some metric and the loss computation. Since, we have batch element with K tag prediction for N tokens, there is more dimension and the normal computation seem inacurate.

## F1 Sequence
A special case of F1 where we have a padding value needed to be mask. Maintly, the process is a flatten step before the forward pass and a test of condition of classes dimensions.

## Sequence Accuracy
In the case of the accuracy computation, we compute with a mask corresponding of the unpadded element.
> No tests

## Sequence Cross Entropy
Flatten before passing to the Cross Entropy.
> No tests


> Should the loss been in a module ?
