### PR TITLE
[bug-fix] Coloring progress bar jupyter

### DIFF
--- a/poutyne/framework/callbacks/color_formatting.py
+++ b/poutyne/framework/callbacks/color_formatting.py
@@ -73,6 +73,7 @@ class ColorProgress:
             color_settings = default_color_settings
 
         if color_settings is not None:
+            self.style_reset = True
             self.text_color = getattr(Fore, color_settings["text_color"])
             self.ratio_color = getattr(Fore, color_settings["ratio_color"])
             self.metric_value_color = getattr(Fore, color_settings["metric_value_color"])
@@ -80,6 +81,7 @@ class ColorProgress:
             self.progress_bar_color = getattr(Fore, color_settings["progress_bar_color"])
 
         else:
+            self.style_reset = False
             self.text_color = ""
             self.ratio_color = ""
             self.metric_value_color = ""
@@ -176,5 +178,6 @@ class ColorProgress:
             value = name_value[1]
             formatted_metrics += self.text_color + name + ":" + self.metric_value_color + value
 
-        formatted_metrics += Style.RESET_ALL
+        if self.style_reset:
+            formatted_metrics += Style.RESET_ALL
         return formatted_metrics

--- a/poutyne/framework/callbacks/color_formatting.py
+++ b/poutyne/framework/callbacks/color_formatting.py
@@ -140,6 +140,9 @@ class ColorProgress:
             update += self._get_formatted_epoch_total_time(epoch_total_time) + self._get_formatted_step(steps, steps)
         update += self._get_formatted_metrics(metrics_str)
 
+        if self.style_reset:
+            update += Style.RESET_ALL
+
         print(update)
         sys.stdout.flush()
 
@@ -178,6 +181,4 @@ class ColorProgress:
             value = name_value[1]
             formatted_metrics += self.text_color + name + ":" + self.metric_value_color + value
 
-        if self.style_reset:
-            formatted_metrics += Style.RESET_ALL
         return formatted_metrics

--- a/poutyne/framework/callbacks/color_formatting.py
+++ b/poutyne/framework/callbacks/color_formatting.py
@@ -151,7 +151,7 @@ class ColorProgress:
         self.progress_bar = True
 
     def _set_epoch_formatted_text(self, epoch_number: int, epochs: int) -> None:
-        self.epoch_formatted_text = self.text_color + "\rEpoch: " + self.ratio_color + "%d/%d " % (epoch_number, epochs)
+        self.epoch_formatted_text = "\r" + self.text_color + "Epoch: " + self.ratio_color + "%d/%d " % (epoch_number, epochs)
 
     def _get_formatted_epoch_total_time(self, epoch_total_time: float) -> str:
         return self.time_color + "%.0fs " % epoch_total_time

--- a/poutyne/framework/callbacks/color_formatting.py
+++ b/poutyne/framework/callbacks/color_formatting.py
@@ -144,8 +144,8 @@ class ColorProgress:
     def set_progress_bar(self, number_steps_per_epoch):
         self.steps_progress_bar = ProgressBar(
             number_steps_per_epoch,
-            bar_format="%s{percentage} |%s{bar}%s| %s" %
-            (self.text_color, self.progress_bar_color, self.text_color, Style.RESET_ALL))
+            bar_format="%s{percentage} |%s{bar}%s|" %
+                       (self.text_color, self.progress_bar_color, self.text_color))
         self.progress_bar = True
 
     def _set_epoch_formatted_text(self, epoch_number: int, epochs: int) -> None:


### PR DESCRIPTION
Using colorama and actual implementation of the progress bar was not working in Jupyter Notebook.

Fixed the use of coloring before return carriage (also corrected the flickering)
Fixed the coloring management (no call to `init()`)
