### PR TITLE
Fix predict api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.x.x
 
-* Add Predict methods to Callback to allow callback to be call during prediction phase.
-* Add Predict methods to Experiment to more easily make predictions with an experiment.
+* Add `predict` methods to Callback to allow callback to be call during prediction phase.
+* Add `infer` methods to Experiment to more easily make inference (predictions) with an experiment.
 * Add a progress bar callback during predictions of a model.
 * Add a method to compare the results of two experiments.
 

--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -881,15 +881,15 @@ class Experiment:
 
         return ret
 
-    def predict(self, x, **kwargs) -> Any:
+    def infer(self, generator, **kwargs) -> Any:
         """
-        Returns the predictions of the network given a dataset ``x``, where the tensors are
+        Returns the inferred predictions of the network given a dataset ``x``, where the tensors are
         converted into Numpy arrays.
 
         Args:
-            x (Union[~torch.Tensor, ~numpy.ndarray] or Union[tuple, list] of Union[~torch.Tensor, ~numpy.ndarray]):
-                Input to the model. Union[Tensor, ndarray] if the model has a single input.
-                Union[tuple, list] of Union[Tensor, ndarray] if the model has multiple inputs.
+            generator: Generator-like object for the dataset. The generator must yield a batch of
+                samples. See the :func:`fit_generator()` method for details on the types of generators
+                supported. This should only yield input data ``x`` and NOT the target ``y``.
             checkpoint (Union[str, int]): Which model checkpoint weights to load for the prediction.
 
                 - If 'best', will load the best weights according to ``monitor_metric`` and ``monitor_mode``.
@@ -904,11 +904,11 @@ class Experiment:
         Returns:
             Return the predictions in the format outputted by the model.
         """
-        return self._predict(self.model.predict, x, **kwargs)
+        return self._predict(self.model.predict_generator, generator, **kwargs)
 
-    def predict_dataset(self, dataset, **kwargs) -> Any:
+    def infer_dataset(self, dataset, **kwargs) -> Any:
         """
-        Returns the predictions of the network given a dataset, where the tensors are
+        Returns the inferred predictions of the network given a dataset, where the tensors are
         converted into Numpy arrays.
 
         Args:
@@ -929,7 +929,7 @@ class Experiment:
         """
         return self._predict(self.model.predict_dataset, dataset, **kwargs)
 
-    def predict_generator(self, generator, **kwargs) -> Any:
+    def infer_generator(self, generator, **kwargs) -> Any:
         """
         Returns the predictions of the network given batches of samples ``x``, where the tensors are
         converted into Numpy arrays.
@@ -957,6 +957,31 @@ class Experiment:
             for the batches is returned with tensors converted into Numpy arrays.
         """
         return self._predict(self.model.predict_generator, generator, **kwargs)
+
+    def infer_data(self, x, **kwargs) -> Any:
+        """
+        Returns the inferred predictions of the network given a dataset ``x``, where the tensors are
+        converted into Numpy arrays.
+
+        Args:
+            x (Union[~torch.Tensor, ~numpy.ndarray] or Union[tuple, list] of Union[~torch.Tensor, ~numpy.ndarray]):
+                Input to the model. Union[Tensor, ndarray] if the model has a single input.
+                Union[tuple, list] of Union[Tensor, ndarray] if the model has multiple inputs.
+            checkpoint (Union[str, int]): Which model checkpoint weights to load for the prediction.
+
+                - If 'best', will load the best weights according to ``monitor_metric`` and ``monitor_mode``.
+                - If 'last', will load the last model checkpoint.
+                - If int, will load the checkpoint of the specified epoch.
+                - If a path (str), will load the model pickled state_dict weights (for instance, saved as
+                  ``torch.save(a_pytorch_network.state_dict(), "./a_path.p")``).
+
+                This argument has no effect when logging is disabled. (Default value = 'best')
+            kwargs: Any keyword arguments to pass to :func:`~Model.predict()`.
+
+        Returns:
+            Return the predictions in the format outputted by the model.
+        """
+        return self._predict(self.model.predict, x, **kwargs)
 
     def _predict(self,
                  evaluate_func: Callable,

--- a/poutyne/framework/experiment.py
+++ b/poutyne/framework/experiment.py
@@ -883,54 +883,6 @@ class Experiment:
 
     def infer(self, generator, **kwargs) -> Any:
         """
-        Returns the inferred predictions of the network given a dataset ``x``, where the tensors are
-        converted into Numpy arrays.
-
-        Args:
-            generator: Generator-like object for the dataset. The generator must yield a batch of
-                samples. See the :func:`fit_generator()` method for details on the types of generators
-                supported. This should only yield input data ``x`` and NOT the target ``y``.
-            checkpoint (Union[str, int]): Which model checkpoint weights to load for the prediction.
-
-                - If 'best', will load the best weights according to ``monitor_metric`` and ``monitor_mode``.
-                - If 'last', will load the last model checkpoint.
-                - If int, will load the checkpoint of the specified epoch.
-                - If a path (str), will load the model pickled state_dict weights (for instance, saved as
-                  ``torch.save(a_pytorch_network.state_dict(), "./a_path.p")``).
-
-                This argument has no effect when logging is disabled. (Default value = 'best')
-            kwargs: Any keyword arguments to pass to :func:`~Model.predict()`.
-
-        Returns:
-            Return the predictions in the format outputted by the model.
-        """
-        return self._predict(self.model.predict_generator, generator, **kwargs)
-
-    def infer_dataset(self, dataset, **kwargs) -> Any:
-        """
-        Returns the inferred predictions of the network given a dataset, where the tensors are
-        converted into Numpy arrays.
-
-        Args:
-            dataset (~torch.utils.data.Dataset): Dataset. Must not return ``y``, just ``x``.
-            checkpoint (Union[str, int]): Which model checkpoint weights to load for the prediction.
-
-                - If 'best', will load the best weights according to ``monitor_metric`` and ``monitor_mode``.
-                - If 'last', will load the last model checkpoint.
-                - If int, will load the checkpoint of the specified epoch.
-                - If a path (str), will load the model pickled state_dict weights (for instance, saved as
-                  ``torch.save(a_pytorch_network.state_dict(), "./a_path.p")``).
-
-                This argument has no effect when logging is disabled. (Default value = 'best')
-            kwargs: Any keyword arguments to pass to :func:`~Model.predict_dataset()`.
-
-        Returns:
-            Return the predictions in the format outputted by the model.
-        """
-        return self._predict(self.model.predict_dataset, dataset, **kwargs)
-
-    def infer_generator(self, generator, **kwargs) -> Any:
-        """
         Returns the predictions of the network given batches of samples ``x``, where the tensors are
         converted into Numpy arrays.
 
@@ -957,6 +909,29 @@ class Experiment:
             for the batches is returned with tensors converted into Numpy arrays.
         """
         return self._predict(self.model.predict_generator, generator, **kwargs)
+
+    def infer_dataset(self, dataset, **kwargs) -> Any:
+        """
+        Returns the inferred predictions of the network given a dataset, where the tensors are
+        converted into Numpy arrays.
+
+        Args:
+            dataset (~torch.utils.data.Dataset): Dataset. Must not return ``y``, just ``x``.
+            checkpoint (Union[str, int]): Which model checkpoint weights to load for the prediction.
+
+                - If 'best', will load the best weights according to ``monitor_metric`` and ``monitor_mode``.
+                - If 'last', will load the last model checkpoint.
+                - If int, will load the checkpoint of the specified epoch.
+                - If a path (str), will load the model pickled state_dict weights (for instance, saved as
+                  ``torch.save(a_pytorch_network.state_dict(), "./a_path.p")``).
+
+                This argument has no effect when logging is disabled. (Default value = 'best')
+            kwargs: Any keyword arguments to pass to :func:`~Model.predict_dataset()`.
+
+        Returns:
+            Return the predictions in the format outputted by the model.
+        """
+        return self._predict(self.model.predict_dataset, dataset, **kwargs)
 
     def infer_data(self, x, **kwargs) -> Any:
         """


### PR DESCRIPTION
- Changed naming of predict API of Experiment to infer to minimize confusion with same methods for `model`.
- Fixed bad use of `model.predict` in `experiment.predict` to `model.predict_generator` and fixed doc.
- Added `experiment.infer_data` to infer on data (use `model.predict`).