### PR TITLE
Improve test notification tests

### DIFF
--- a/poutyne/framework/callbacks/notification.py
+++ b/poutyne/framework/callbacks/notification.py
@@ -104,7 +104,7 @@ class NotificationCallback(Callback):
         'End of the testing for the experiment experiment_name' if an experiment name is given.
         """
 
-        message = f"Here the epoch metrics: \n{self._format_logs(logs)}"
+        message = f"Here the test metrics: \n{self._format_logs(logs)}"
         self.notificator.send_notification(message, subject=f"End of the testing{self.experiment_name_msg}.")
 
     @staticmethod

--- a/tests/framework/callbacks/test_notification.py
+++ b/tests/framework/callbacks/test_notification.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import List
 from unittest import TestCase
 from unittest.mock import MagicMock, call
 
@@ -16,7 +16,7 @@ from tests.framework.tools import (
     some_metric_2_value,
     some_metric_1_value,
     SomeConstantEpochMetric,
-    some_constant_epoch_metric_value,
+    some_constant_epoch_metric_value
 )
 
 
@@ -33,6 +33,9 @@ class NotificationCallbackTest(TestCase):
 
         self.train_generator = some_data_tensor_generator(NotificationCallbackTest.batch_size)
         self.valid_generator = some_data_tensor_generator(NotificationCallbackTest.batch_size)
+
+        self.some_x_data = torch.rand(NotificationCallbackTest.batch_size, 1)
+        self.some_y_data = torch.rand(NotificationCallbackTest.batch_size, 1)
 
         torch.manual_seed(42)
         self.pytorch_network = nn.Linear(1, 1)
@@ -79,8 +82,9 @@ class NotificationCallbackTest(TestCase):
             validation_steps=NotificationCallbackTest.steps_per_epoch,
             callbacks=[notification_callback],
         )
+        self._build_notificator_call(logs)
 
-        self._test_notificator_call(logs)
+        self.assert_mock_calls(self.call_list)
 
     def test_givenANotificationCallbackWithExperimentName_whenTrainingLoop_thenSendNotificationWithExperimentName(self):
         a_experiment_name = "A experiment name"
@@ -96,22 +100,54 @@ class NotificationCallbackTest(TestCase):
             callbacks=[notification_callback],
         )
 
-        self._test_notificator_call(logs, experiment_name=a_experiment_name)
+        self._build_notificator_call(logs, experiment_name=a_experiment_name)
 
-    def _test_notificator_call(self, logs: Dict, experiment_name=None):
+        self.assert_mock_calls(self.call_list)
+
+    def test_givenANotificationCallback_whenTestLoop_thenSendNotification(self):
+        notification_callback = NotificationCallback(notificator=self.notificator_mock)
+        res = self.model.evaluate(x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback],
+                                  return_dict_format=True)
+
+        self._build_notificator_call(res, mode="testing")
+
+        self.assert_mock_calls(self.call_list)
+
+    def test_givenANotificationCallbackWithExperimentName_whenTestLoop_thenSendNotificationWithExperimentName(self):
+        a_experiment_name = "A experiment name"
+        notification_callback = NotificationCallback(
+            notificator=self.notificator_mock, experiment_name=a_experiment_name
+        )
+        res = self.model.evaluate(x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback],
+                                  return_dict_format=True)
+
+        self._build_notificator_call(res, mode="testing", experiment_name=a_experiment_name)
+
+        self.assert_mock_calls(self.call_list)
+
+    def assert_mock_calls(self, call_list: List):
+        method_calls = self.notificator_mock.method_calls
+        self.assertEqual(len(method_calls), len(call_list))
+        self.assertEqual(method_calls, call_list)
+
+    def _build_notificator_call(self, logs, experiment_name=None, mode: str = "training"):
         experiment_name_text = f" for {experiment_name}" if experiment_name is not None else ""
         call_list = []
-        call_list.append(call.send_notification('', subject=f'Start of the training{experiment_name_text}.'))
-        for batch_log in logs:
-            formatted_log_data = " ".join([f"{key}: {value}\n" for key, value in batch_log.items()])
-            call_list.append(
-                call.send_notification(
-                    f"Here the epoch metrics: \n{formatted_log_data}",
-                    subject=f"Epoch {batch_log['epoch']} is done{experiment_name_text}.",
-                )
-            )
-        call_list.append(call.send_notification('', subject=f'End of the training{experiment_name_text}.'))
+        call_list.append(call.send_notification('', subject=f'Start of the {mode}{experiment_name_text}.'))
 
-        method_calls = self.notificator_mock.method_calls
-        self.assertEqual(len(method_calls), len(call_list))  # for set_model and set param
-        self.assertEqual(method_calls, call_list)
+        if mode == "training":
+            for batch_log in logs:
+                formatted_log_data = " ".join([f"{key}: {value}\n" for key, value in batch_log.items()])
+                call_list.append(
+                    call.send_notification(
+                        f"Here the epoch metrics: \n{formatted_log_data}",
+                        subject=f"Epoch {batch_log['epoch']} is done{experiment_name_text}.",
+                    )
+                )
+                message = ''
+        elif mode == "testing":
+            formatted_log_data = " ".join([f"{key}: {value}\n" for key, value in logs.items()])
+            message = f"Here the test metrics: \n{formatted_log_data}"
+
+        call_list.append(call.send_notification(message, subject=f'End of the {mode}{experiment_name_text}.'))
+        self.call_list = call_list

--- a/tests/framework/callbacks/test_notification.py
+++ b/tests/framework/callbacks/test_notification.py
@@ -82,9 +82,9 @@ class NotificationCallbackTest(TestCase):
             validation_steps=NotificationCallbackTest.steps_per_epoch,
             callbacks=[notification_callback],
         )
-        self._build_notificator_call(logs)
+        call_list = self._build_notificator_call(logs)
 
-        self._assert_mock_calls(self.call_list)
+        self._assert_mock_calls(call_list)
 
     def test_givenANotificationCallbackWithExperimentName_whenTrainingLoop_thenSendNotificationWithExperimentName(self):
         a_experiment_name = "A experiment name"
@@ -100,9 +100,9 @@ class NotificationCallbackTest(TestCase):
             callbacks=[notification_callback],
         )
 
-        self._build_notificator_call(logs, experiment_name=a_experiment_name)
+        call_list = self._build_notificator_call(logs, experiment_name=a_experiment_name)
 
-        self._assert_mock_calls(self.call_list)
+        self._assert_mock_calls(call_list)
 
     def test_givenANotificationCallback_whenTestLoop_thenSendNotification(self):
         notification_callback = NotificationCallback(notificator=self.notificator_mock)
@@ -110,9 +110,9 @@ class NotificationCallbackTest(TestCase):
             x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback], return_dict_format=True
         )
 
-        self._build_notificator_call(res, mode="testing")
+        call_list = self._build_notificator_call(res, mode="testing")
 
-        self._assert_mock_calls(self.call_list)
+        self._assert_mock_calls(call_list)
 
     def test_givenANotificationCallbackWithExperimentName_whenTestLoop_thenSendNotificationWithExperimentName(self):
         a_experiment_name = "A experiment name"
@@ -123,16 +123,17 @@ class NotificationCallbackTest(TestCase):
             x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback], return_dict_format=True
         )
 
-        self._build_notificator_call(res, mode="testing", experiment_name=a_experiment_name)
+        call_list = self._build_notificator_call(res, mode="testing", experiment_name=a_experiment_name)
 
-        self._assert_mock_calls(self.call_list)
+        self._assert_mock_calls(call_list)
 
     def _assert_mock_calls(self, call_list: List):
         method_calls = self.notificator_mock.method_calls
         self.assertEqual(len(method_calls), len(call_list))
         self.assertEqual(method_calls, call_list)
 
-    def _build_notificator_call(self, logs, experiment_name=None, mode: str = "training"):
+    @staticmethod
+    def _build_notificator_call(logs, experiment_name=None, mode: str = "training") -> List:
         experiment_name_text = f" for {experiment_name}" if experiment_name is not None else ""
         call_list = []
         call_list.append(call.send_notification('', subject=f'Start of the {mode}{experiment_name_text}.'))
@@ -152,4 +153,4 @@ class NotificationCallbackTest(TestCase):
             message = f"Here the test metrics: \n{formatted_log_data}"
 
         call_list.append(call.send_notification(message, subject=f'End of the {mode}{experiment_name_text}.'))
-        self.call_list = call_list
+        return call_list

--- a/tests/framework/callbacks/test_notification.py
+++ b/tests/framework/callbacks/test_notification.py
@@ -84,7 +84,7 @@ class NotificationCallbackTest(TestCase):
         )
         self._build_notificator_call(logs)
 
-        self.assert_mock_calls(self.call_list)
+        self._assert_mock_calls(self.call_list)
 
     def test_givenANotificationCallbackWithExperimentName_whenTrainingLoop_thenSendNotificationWithExperimentName(self):
         a_experiment_name = "A experiment name"
@@ -102,7 +102,7 @@ class NotificationCallbackTest(TestCase):
 
         self._build_notificator_call(logs, experiment_name=a_experiment_name)
 
-        self.assert_mock_calls(self.call_list)
+        self._assert_mock_calls(self.call_list)
 
     def test_givenANotificationCallback_whenTestLoop_thenSendNotification(self):
         notification_callback = NotificationCallback(notificator=self.notificator_mock)
@@ -112,7 +112,7 @@ class NotificationCallbackTest(TestCase):
 
         self._build_notificator_call(res, mode="testing")
 
-        self.assert_mock_calls(self.call_list)
+        self._assert_mock_calls(self.call_list)
 
     def test_givenANotificationCallbackWithExperimentName_whenTestLoop_thenSendNotificationWithExperimentName(self):
         a_experiment_name = "A experiment name"
@@ -125,9 +125,9 @@ class NotificationCallbackTest(TestCase):
 
         self._build_notificator_call(res, mode="testing", experiment_name=a_experiment_name)
 
-        self.assert_mock_calls(self.call_list)
+        self._assert_mock_calls(self.call_list)
 
-    def assert_mock_calls(self, call_list: List):
+    def _assert_mock_calls(self, call_list: List):
         method_calls = self.notificator_mock.method_calls
         self.assertEqual(len(method_calls), len(call_list))
         self.assertEqual(method_calls, call_list)

--- a/tests/framework/callbacks/test_notification.py
+++ b/tests/framework/callbacks/test_notification.py
@@ -16,7 +16,7 @@ from tests.framework.tools import (
     some_metric_2_value,
     some_metric_1_value,
     SomeConstantEpochMetric,
-    some_constant_epoch_metric_value
+    some_constant_epoch_metric_value,
 )
 
 
@@ -106,8 +106,9 @@ class NotificationCallbackTest(TestCase):
 
     def test_givenANotificationCallback_whenTestLoop_thenSendNotification(self):
         notification_callback = NotificationCallback(notificator=self.notificator_mock)
-        res = self.model.evaluate(x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback],
-                                  return_dict_format=True)
+        res = self.model.evaluate(
+            x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback], return_dict_format=True
+        )
 
         self._build_notificator_call(res, mode="testing")
 
@@ -118,8 +119,9 @@ class NotificationCallbackTest(TestCase):
         notification_callback = NotificationCallback(
             notificator=self.notificator_mock, experiment_name=a_experiment_name
         )
-        res = self.model.evaluate(x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback],
-                                  return_dict_format=True)
+        res = self.model.evaluate(
+            x=self.some_x_data, y=self.some_y_data, callbacks=[notification_callback], return_dict_format=True
+        )
 
         self._build_notificator_call(res, mode="testing", experiment_name=a_experiment_name)
 


### PR DESCRIPTION
Fix a minor typo in the testing notification (it was saying epoch at the end of a testing phase).
Improve test coverage.