### PR TITLE
fix: np.Inf was deprecated forever and is now gone

### DIFF
--- a/poutyne/framework/callbacks/earlystopping.py
+++ b/poutyne/framework/callbacks/earlystopping.py
@@ -122,7 +122,7 @@ class EarlyStopping(Callback):
         # Allow instances to be re-used
         self.wait = 0
         self.stopped_epoch = 0
-        self.best = np.Inf if self.mode == 'min' else -np.Inf
+        self.best = np.inf if self.mode == 'min' else -np.inf
 
     def on_epoch_end(self, epoch_number: int, logs: Dict):
         current = logs[self.monitor]


### PR DESCRIPTION
As the title says :-) `poutyne.EarlyStopping` is not compatible with NumPy 2.0, which has finally removed all of the various aliases to `np.inf`.

This fixes that.  It seems there aren't any other places where you were using `np.Inf`.  Not sure if there are any other NumPy 2.0 compatibility issues.