### PR TITLE
Add type annotations to forward method in example code

### DIFF
--- a/slides/src/code/example_pytorch.py
+++ b/slides/src/code/example_pytorch.py
@@ -7,5 +7,5 @@ class MnistLogistic(nn.Module):
                                     math.sqrt(784)) # W
         self.bias = nn.Parameter(torch.zeros(10)) # b
 
-    def forward(self, xb):
+    def forward(self, xb: torch.Tensor) -> torch.Tensor:
         return xb.matmul(self.weights) + self.bias # xW + b


### PR DESCRIPTION
### 问题背景
在 `slides/src/code/example_pytorch.py` 中的 `MnistLogistic` 类的 `forward` 方法缺少参数和返回值类型注解。这降低了代码的可读性和可维护性，并且不符合Python类型提示的最佳实践。

### 修改内容
- 为 `forward` 方法的参数 `xb` 添加了 `torch.Tensor` 类型注解。
- 为 `forward` 方法的返回值添加了 `torch.Tensor` 类型注解。

### 验证方式
- 这是一个示例代码，因此主要确保代码语法正确，并且类型注解与PyTorch兼容。
- 可以通过运行Python解释器或使用类型检查工具如mypy来验证类型正确性，但作为示例代码，重点是保持代码清晰和一致性。